### PR TITLE
updated jackson dependencies to 2.12.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,12 +111,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>[2.9.10.5,)</version>
+            <version>2.12.3</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.10.2</version>
+            <version>2.12.3</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
aggregating pending changes into a single `gfs-gordon-now-core-build` branch to avoid cluttering the `master` branch on this fork while also maintaining a singular location where the _"fixed"_ version of the lib lives